### PR TITLE
bpf: Return -EINVAL on calling bpf_setsockopt(TCP_SAVED_SYN)

### DIFF
--- a/net/core/filter.c
+++ b/net/core/filter.c
@@ -5206,6 +5206,9 @@ static int sol_tcp_sockopt(struct sock *sk, int optname,
 		return do_tcp_getsockopt(sk, SOL_TCP, optname,
 					 KERNEL_SOCKPTR(optval),
 					 KERNEL_SOCKPTR(optlen));
+	} else {
+		if (optname == TCP_SAVED_SYN)
+			return -EINVAL;
 	}
 
 	return do_tcp_setsockopt(sk, SOL_TCP, optname,


### PR DESCRIPTION
Pull request for series with
subject: bpf: Return -EINVAL on calling bpf_setsockopt(TCP_SAVED_SYN)
version: 1
url: https://patchwork.kernel.org/project/netdevbpf/list/?series=688641
