### PR TITLE
arm64/syscall: Include asm/ptrace.h in syscall_wrapper header.

### DIFF
--- a/arch/arm64/include/asm/syscall_wrapper.h
+++ b/arch/arm64/include/asm/syscall_wrapper.h
@@ -8,7 +8,7 @@
 #ifndef __ASM_SYSCALL_WRAPPER_H
 #define __ASM_SYSCALL_WRAPPER_H
 
-struct pt_regs;
+#include <asm/ptrace.h>
 
 #define SC_ARM64_REGS_TO_ARGS(x, ...)				\
 	__MAP(x,__SC_ARGS					\


### PR DESCRIPTION
Pull request for series with
subject: arm64/syscall: Include asm/ptrace.h in syscall_wrapper header.
version: 1
url: https://patchwork.kernel.org/project/netdevbpf/list/?series=690647
