### PR TITLE
selftests/bpf: Fix test_progs compilation failure in 32-bit arch

### DIFF
--- a/tools/testing/selftests/bpf/test_progs.c
+++ b/tools/testing/selftests/bpf/test_progs.c
@@ -1010,7 +1010,7 @@ static inline const char *str_msg(const struct msg *msg, char *buf)
 			msg->subtest_done.have_log);
 		break;
 	case MSG_TEST_LOG:
-		sprintf(buf, "MSG_TEST_LOG (cnt: %ld, last: %d)",
+		sprintf(buf, "MSG_TEST_LOG (cnt: %zu, last: %d)",
 			strlen(msg->test_log.log_buf),
 			msg->test_log.is_last);
 		break;


### PR DESCRIPTION
Pull request for series with
subject: selftests/bpf: Fix test_progs compilation failure in 32-bit arch
version: 1
url: https://patchwork.kernel.org/project/netdevbpf/list/?series=693022
