### PR TITLE
selftests/bpf: Fix casting error when cross-compiling test_verifier for 32-bit platforms

### DIFF
--- a/tools/testing/selftests/bpf/test_verifier.c
+++ b/tools/testing/selftests/bpf/test_verifier.c
@@ -1260,7 +1260,7 @@ static int get_xlated_program(int fd_prog, struct bpf_insn **buf, int *cnt)
 
 	bzero(&info, sizeof(info));
 	info.xlated_prog_len = xlated_prog_len;
-	info.xlated_prog_insns = (__u64)*buf;
+	info.xlated_prog_insns = (__u64)(unsigned long)*buf;
 	if (bpf_obj_get_info_by_fd(fd_prog, &info, &info_len)) {
 		perror("second bpf_obj_get_info_by_fd failed");
 		goto out_free_buf;


### PR DESCRIPTION
Pull request for series with
subject: selftests/bpf: Fix casting error when cross-compiling test_verifier for 32-bit platforms
version: 1
url: https://patchwork.kernel.org/project/netdevbpf/list/?series=693208
