### PR TITLE
selftests/bpf: Fix "missing ENDBR" BUG for destructor kfunc

### DIFF
--- a/include/linux/btf_ids.h
+++ b/include/linux/btf_ids.h
@@ -266,4 +266,11 @@ MAX_BTF_TRACING_TYPE,
 
 extern u32 btf_tracing_ids[];
 
+#if defined(CONFIG_X86_KERNEL_IBT) && !defined(__DISABLE_EXPORTS)
+#define FUNC_IBT_NOSEAL(name)					\
+	asm(IBT_NOSEAL(#name));
+#else
+#define FUNC_IBT_NOSEAL(name)
+#endif /* CONFIG_X86_KERNEL_IBT */
+
 #endif

--- a/net/bpf/test_run.c
+++ b/net/bpf/test_run.c
@@ -597,9 +597,13 @@ noinline void bpf_kfunc_call_test_release(struct prog_test_ref_kfunc *p)
 	refcount_dec(&p->cnt);
 }
 
+FUNC_IBT_NOSEAL(bpf_kfunc_call_test_release)
+
 noinline void bpf_kfunc_call_memb_release(struct prog_test_member *p)
 {
 }
+
+FUNC_IBT_NOSEAL(bpf_kfunc_call_memb_release)
 
 noinline void bpf_kfunc_call_memb1_release(struct prog_test_member1 *p)
 {


### PR DESCRIPTION
Pull request for series with
subject: selftests/bpf: Fix "missing ENDBR" BUG for destructor kfunc
version: 2
url: https://patchwork.kernel.org/project/netdevbpf/list/?series=697945
