### PR TITLE
Check timer_off for map_in_map only when map value has timer

### DIFF
--- a/kernel/bpf/map_in_map.c
+++ b/kernel/bpf/map_in_map.c
@@ -80,11 +80,18 @@ void bpf_map_meta_free(struct bpf_map *map_meta)
 bool bpf_map_meta_equal(const struct bpf_map *meta0,
 			const struct bpf_map *meta1)
 {
+	bool timer_off_equal;
+
+	if (!map_value_has_timer(meta0) && !map_value_has_timer(meta1))
+		timer_off_equal = true;
+	else
+		timer_off_equal = meta0->timer_off == meta1->timer_off;
+
 	/* No need to compare ops because it is covered by map_type */
 	return meta0->map_type == meta1->map_type &&
 		meta0->key_size == meta1->key_size &&
 		meta0->value_size == meta1->value_size &&
-		meta0->timer_off == meta1->timer_off &&
+		timer_off_equal &&
 		meta0->map_flags == meta1->map_flags &&
 		bpf_map_equal_kptr_off_tab(meta0, meta1);
 }

--- a/tools/testing/selftests/bpf/progs/test_btf_map_in_map.c
+++ b/tools/testing/selftests/bpf/progs/test_btf_map_in_map.c
@@ -118,6 +118,28 @@ struct outer_sockarr_sz1 {
 	.values = { (void *)&sockarr_sz1 },
 };
 
+struct inner_key {
+	__u32 x;
+};
+
+struct inner_value {
+	__u32 y;
+};
+
+struct inner {
+	__uint(type, BPF_MAP_TYPE_LRU_HASH);
+	__uint(max_entries, 1);
+	__type(key, struct inner_key);
+	__type(value, struct inner_value);
+} inner SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY_OF_MAPS);
+	__uint(max_entries, 1);
+	__type(key, __u32);
+	__array(values, struct inner);
+} outer SEC(".maps");
+
 int input = 0;
 
 SEC("raw_tp/sys_enter")


### PR DESCRIPTION
Pull request for series with
subject: Check timer_off for map_in_map only when map value has timer
version: 1
url: https://patchwork.kernel.org/project/netdevbpf/list/?series=699389
