### PR TITLE
Replace invocations of prandom_u32 with get_random_u32

### DIFF
--- a/arch/x86/mm/kaslr.c
+++ b/arch/x86/mm/kaslr.c
@@ -123,7 +123,7 @@ void __init kernel_randomize_memory(void)
 		 * available.
 		 */
 		entropy = remain_entropy / (ARRAY_SIZE(kaslr_regions) - i);
-		prandom_bytes_state(&rand_state, &rand, sizeof(rand));
+		predictable_rng_prandom_bytes_state(&rand_state, &rand, sizeof(rand));
 		entropy = (rand % (entropy + 1)) & PUD_MASK;
 		vaddr += entropy;
 		*kaslr_regions[i].base = vaddr;

--- a/drivers/gpu/drm/i915/gem/selftests/huge_pages.c
+++ b/drivers/gpu/drm/i915/gem/selftests/huge_pages.c
@@ -1294,7 +1294,7 @@ static u32 igt_random_size(struct rnd_state *prng,
 	GEM_BUG_ON(min_page_size > max_page_size);
 
 	mask = ((max_page_size << 1ULL) - 1) & PAGE_MASK;
-	size = prandom_u32_state(prng) & mask;
+	size = predictable_rng_prandom_u32_state(prng) & mask;
 	if (size < min_page_size)
 		size |= min_page_size;
 

--- a/drivers/gpu/drm/i915/gem/selftests/i915_gem_client_blt.c
+++ b/drivers/gpu/drm/i915/gem/selftests/i915_gem_client_blt.c
@@ -630,7 +630,7 @@ static int tiled_blits_prepare(struct tiled_blits *t,
 
 	/* Use scratch to fill objects */
 	for (i = 0; i < ARRAY_SIZE(t->buffers); i++) {
-		fill_scratch(t, map, prandom_u32_state(prng));
+		fill_scratch(t, map, predictable_rng_prandom_u32_state(prng));
 		GEM_BUG_ON(verify_buffer(t, &t->scratch, prng));
 
 		err = tiled_blit(t,

--- a/drivers/gpu/drm/i915/gem/selftests/i915_gem_coherency.c
+++ b/drivers/gpu/drm/i915/gem/selftests/i915_gem_coherency.c
@@ -371,7 +371,7 @@ static int igt_gem_coherency(void *arg)
 
 					i915_random_reorder(offsets, ncachelines, &prng);
 					for (n = 0; n < count; n++)
-						values[n] = prandom_u32_state(&prng);
+						values[n] = predictable_rng_prandom_u32_state(&prng);
 
 					for (n = 0; n < count; n++) {
 						err = over->set(&ctx, offsets[n], ~values[n]);

--- a/drivers/gpu/drm/i915/gem/selftests/i915_gem_context.c
+++ b/drivers/gpu/drm/i915/gem/selftests/i915_gem_context.c
@@ -1407,7 +1407,7 @@ static int igt_ctx_readonly(void *arg)
 					goto out_file;
 				}
 
-				if (prandom_u32_state(&prng) & 1)
+				if (predictable_rng_prandom_u32_state(&prng) & 1)
 					i915_gem_object_set_readonly(obj);
 			}
 

--- a/drivers/gpu/drm/i915/gt/selftest_lrc.c
+++ b/drivers/gpu/drm/i915/gt/selftest_lrc.c
@@ -1760,7 +1760,7 @@ static struct i915_request *garbage(struct intel_context *ce,
 	if (err)
 		return ERR_PTR(err);
 
-	prandom_bytes_state(prng,
+	predictable_rng_prandom_bytes_state(prng,
 			    ce->lrc_reg_state,
 			    ce->engine->context_size -
 			    LRC_STATE_OFFSET);

--- a/drivers/gpu/drm/i915/gt/selftest_migrate.c
+++ b/drivers/gpu/drm/i915/gt/selftest_migrate.c
@@ -551,7 +551,7 @@ static int threaded_migrate(struct intel_migrate *migrate,
 
 		thread[i].migrate = migrate;
 		thread[i].prng =
-			I915_RND_STATE_INITIALIZER(prandom_u32_state(&prng));
+			I915_RND_STATE_INITIALIZER(predictable_rng_prandom_u32_state(&prng));
 
 		tsk = kthread_run(fn, &thread[i], "igt-%d", i);
 		if (IS_ERR(tsk)) {

--- a/drivers/gpu/drm/i915/gt/selftest_timeline.c
+++ b/drivers/gpu/drm/i915/gt/selftest_timeline.c
@@ -308,7 +308,7 @@ static int bench_sync(void *arg)
 		u32 x;
 
 		/* Make sure the compiler doesn't optimise away the prng call */
-		WRITE_ONCE(x, prandom_u32_state(&prng));
+		WRITE_ONCE(x, predictable_rng_prandom_u32_state(&prng));
 
 		count++;
 	} while (!time_after(jiffies, end_time));
@@ -393,7 +393,7 @@ static int bench_sync(void *arg)
 	end_time = jiffies + HZ/10;
 	do {
 		u32 id = random_engine(&prng);
-		u32 seqno = prandom_u32_state(&prng);
+		u32 seqno = predictable_rng_prandom_u32_state(&prng);
 
 		if (!__intel_timeline_sync_is_later(&tl, id, seqno))
 			__intel_timeline_sync_set(&tl, id, seqno);

--- a/drivers/gpu/drm/i915/selftests/i915_random.c
+++ b/drivers/gpu/drm/i915/selftests/i915_random.c
@@ -35,9 +35,9 @@ u64 i915_prandom_u64_state(struct rnd_state *rnd)
 {
 	u64 x;
 
-	x = prandom_u32_state(rnd);
+	x = predictable_rng_prandom_u32_state(rnd);
 	x <<= 32;
-	x |= prandom_u32_state(rnd);
+	x |= predictable_rng_prandom_u32_state(rnd);
 
 	return x;
 }

--- a/drivers/gpu/drm/i915/selftests/i915_random.h
+++ b/drivers/gpu/drm/i915/selftests/i915_random.h
@@ -40,13 +40,13 @@
 	struct rnd_state name__ = I915_RND_STATE_INITIALIZER(i915_selftest.random_seed)
 
 #define I915_RND_SUBSTATE(name__, parent__) \
-	struct rnd_state name__ = I915_RND_STATE_INITIALIZER(prandom_u32_state(&(parent__)))
+	struct rnd_state name__ = I915_RND_STATE_INITIALIZER(predictable_rng_prandom_u32_state(&(parent__)))
 
 u64 i915_prandom_u64_state(struct rnd_state *rnd);
 
 static inline u32 i915_prandom_u32_max_state(u32 ep_ro, struct rnd_state *state)
 {
-	return upper_32_bits(mul_u32_u32(prandom_u32_state(state), ep_ro));
+	return upper_32_bits(mul_u32_u32(predictable_rng_prandom_u32_state(state), ep_ro));
 }
 
 unsigned int *i915_random_order(unsigned int count,

--- a/drivers/gpu/drm/i915/selftests/i915_syncmap.c
+++ b/drivers/gpu/drm/i915/selftests/i915_syncmap.c
@@ -223,7 +223,7 @@ static int igt_syncmap_one(void *arg)
 
 		for (loop = 0; loop <= max; loop++) {
 			err = check_one(&sync, context,
-					prandom_u32_state(&prng));
+					predictable_rng_prandom_u32_state(&prng));
 			if (err)
 				goto out;
 		}
@@ -575,7 +575,7 @@ static int igt_syncmap_random(void *arg)
 		u32 last_seqno = seqno;
 		bool expect;
 
-		seqno = prandom_u32_state(&prng);
+		seqno = predictable_rng_prandom_u32_state(&prng);
 		expect = seqno_later(last_seqno, seqno);
 
 		for (i = 0; i < count; i++) {

--- a/drivers/gpu/drm/i915/selftests/intel_memory_region.c
+++ b/drivers/gpu/drm/i915/selftests/intel_memory_region.c
@@ -758,7 +758,7 @@ static int igt_gpu_write(struct i915_gem_context *ctx,
 	i = 0;
 	engines = i915_gem_context_lock_engines(ctx);
 	do {
-		u32 rng = prandom_u32_state(&prng);
+		u32 rng = predictable_rng_prandom_u32_state(&prng);
 		u32 dword = offset_in_page(rng) / 4;
 
 		ce = engines->engines[order[i] % engines->num_engines];
@@ -929,7 +929,7 @@ static int igt_lmem_create_cleared_cpu(void *arg)
 			goto out_unpin;
 		}
 
-		val = prandom_u32_state(&prng);
+		val = predictable_rng_prandom_u32_state(&prng);
 
 		memset32(vaddr, val, obj->base.size / sizeof(u32));
 
@@ -972,7 +972,7 @@ static int igt_lmem_write_gpu(void *arg)
 		goto out_file;
 	}
 
-	sz = round_up(prandom_u32_state(&prng) % SZ_32M, PAGE_SIZE);
+	sz = round_up(predictable_rng_prandom_u32_state(&prng) % SZ_32M, PAGE_SIZE);
 
 	obj = i915_gem_object_create_lmem(i915, sz, 0);
 	if (IS_ERR(obj)) {
@@ -1046,7 +1046,7 @@ static int igt_lmem_write_cpu(void *arg)
 
 	pr_info("%s: using %s\n", __func__, engine->name);
 
-	sz = round_up(prandom_u32_state(&prng) % SZ_32M, PAGE_SIZE);
+	sz = round_up(predictable_rng_prandom_u32_state(&prng) % SZ_32M, PAGE_SIZE);
 	sz = max_t(u32, 2 * PAGE_SIZE, sz);
 
 	obj = i915_gem_object_create_lmem(i915, sz, I915_BO_ALLOC_CONTIGUOUS);
@@ -1115,7 +1115,7 @@ static int igt_lmem_write_cpu(void *arg)
 		offset = igt_random_offset(&prng, 0, obj->base.size,
 					   size, align);
 
-		val = prandom_u32_state(&prng);
+		val = predictable_rng_prandom_u32_state(&prng);
 		memset32(vaddr + offset / sizeof(u32), val ^ 0xdeadbeaf,
 			 size / sizeof(u32));
 

--- a/drivers/gpu/drm/i915/selftests/scatterlist.c
+++ b/drivers/gpu/drm/i915/selftests/scatterlist.c
@@ -187,7 +187,7 @@ static unsigned int random(unsigned long n,
 			   unsigned long count,
 			   struct rnd_state *rnd)
 {
-	return 1 + (prandom_u32_state(rnd) % 1024);
+	return 1 + (predictable_rng_prandom_u32_state(rnd) % 1024);
 }
 
 static unsigned int random_page_size_pages(unsigned long n,
@@ -201,7 +201,7 @@ static unsigned int random_page_size_pages(unsigned long n,
 		BIT(21) >> PAGE_SHIFT,
 	};
 
-	return page_count[(prandom_u32_state(rnd) % 3)];
+	return page_count[(predictable_rng_prandom_u32_state(rnd) % 3)];
 }
 
 static inline bool page_contiguous(struct page *first,

--- a/drivers/gpu/drm/lib/drm_random.c
+++ b/drivers/gpu/drm/lib/drm_random.c
@@ -9,7 +9,7 @@
 
 u32 drm_prandom_u32_max_state(u32 ep_ro, struct rnd_state *state)
 {
-	return upper_32_bits((u64)prandom_u32_state(state) * ep_ro);
+	return upper_32_bits((u64)predictable_rng_prandom_u32_state(state) * ep_ro);
 }
 EXPORT_SYMBOL(drm_prandom_u32_max_state);
 

--- a/drivers/mtd/tests/oobtest.c
+++ b/drivers/mtd/tests/oobtest.c
@@ -60,7 +60,7 @@ static int write_eraseblock(int ebnum)
 	int err = 0;
 	loff_t addr = (loff_t)ebnum * mtd->erasesize;
 
-	prandom_bytes_state(&rnd_state, writebuf, use_len_max * pgcnt);
+	predictable_rng_prandom_bytes_state(&rnd_state, writebuf, use_len_max * pgcnt);
 	for (i = 0; i < pgcnt; ++i, addr += mtd->writesize) {
 		ops.mode      = MTD_OPS_AUTO_OOB;
 		ops.len       = 0;
@@ -170,7 +170,7 @@ static int verify_eraseblock(int ebnum)
 	loff_t addr = (loff_t)ebnum * mtd->erasesize;
 	size_t bitflips;
 
-	prandom_bytes_state(&rnd_state, writebuf, use_len_max * pgcnt);
+	predictable_rng_prandom_bytes_state(&rnd_state, writebuf, use_len_max * pgcnt);
 	for (i = 0; i < pgcnt; ++i, addr += mtd->writesize) {
 		ops.mode      = MTD_OPS_AUTO_OOB;
 		ops.len       = 0;
@@ -268,7 +268,7 @@ static int verify_eraseblock_in_one_go(int ebnum)
 	size_t bitflips;
 	int i;
 
-	prandom_bytes_state(&rnd_state, writebuf, len);
+	predictable_rng_prandom_bytes_state(&rnd_state, writebuf, len);
 	ops.mode      = MTD_OPS_AUTO_OOB;
 	ops.len       = 0;
 	ops.retlen    = 0;
@@ -642,7 +642,7 @@ static int __init mtd_oobtest_init(void)
 		if (bbt[i] || bbt[i + 1])
 			continue;
 		addr = (loff_t)(i + 1) * mtd->erasesize - mtd->writesize;
-		prandom_bytes_state(&rnd_state, writebuf, sz * cnt);
+		predictable_rng_prandom_bytes_state(&rnd_state, writebuf, sz * cnt);
 		for (pg = 0; pg < cnt; ++pg) {
 			ops.mode      = MTD_OPS_AUTO_OOB;
 			ops.len       = 0;
@@ -673,7 +673,7 @@ static int __init mtd_oobtest_init(void)
 	for (i = 0; i < ebcnt - 1; ++i) {
 		if (bbt[i] || bbt[i + 1])
 			continue;
-		prandom_bytes_state(&rnd_state, writebuf, mtd->oobavail * 2);
+		predictable_rng_prandom_bytes_state(&rnd_state, writebuf, mtd->oobavail * 2);
 		addr = (loff_t)(i + 1) * mtd->erasesize - mtd->writesize;
 		ops.mode      = MTD_OPS_AUTO_OOB;
 		ops.len       = 0;

--- a/drivers/mtd/tests/pagetest.c
+++ b/drivers/mtd/tests/pagetest.c
@@ -42,7 +42,7 @@ static int write_eraseblock(int ebnum)
 {
 	loff_t addr = (loff_t)ebnum * mtd->erasesize;
 
-	prandom_bytes_state(&rnd_state, writebuf, mtd->erasesize);
+	predictable_rng_prandom_bytes_state(&rnd_state, writebuf, mtd->erasesize);
 	cond_resched();
 	return mtdtest_write(mtd, addr, mtd->erasesize, writebuf);
 }
@@ -62,7 +62,7 @@ static int verify_eraseblock(int ebnum)
 	for (i = 0; i < ebcnt && bbt[ebcnt - i - 1]; ++i)
 		addrn -= mtd->erasesize;
 
-	prandom_bytes_state(&rnd_state, writebuf, mtd->erasesize);
+	predictable_rng_prandom_bytes_state(&rnd_state, writebuf, mtd->erasesize);
 	for (j = 0; j < pgcnt - 1; ++j, addr += pgsize) {
 		/* Do a read to set the internal dataRAMs to different data */
 		err = mtdtest_read(mtd, addr0, bufsize, twopages);
@@ -97,7 +97,7 @@ static int verify_eraseblock(int ebnum)
 		if (err)
 			return err;
 		memcpy(boundary, writebuf + mtd->erasesize - pgsize, pgsize);
-		prandom_bytes_state(&rnd_state, boundary + pgsize, pgsize);
+		predictable_rng_prandom_bytes_state(&rnd_state, boundary + pgsize, pgsize);
 		if (memcmp(twopages, boundary, bufsize)) {
 			pr_err("error: verify failed at %#llx\n",
 			       (long long)addr);
@@ -210,7 +210,7 @@ static int erasecrosstest(void)
 		return err;
 
 	pr_info("writing 1st page of block %d\n", ebnum);
-	prandom_bytes_state(&rnd_state, writebuf, pgsize);
+	predictable_rng_prandom_bytes_state(&rnd_state, writebuf, pgsize);
 	strcpy(writebuf, "There is no data like this!");
 	err = mtdtest_write(mtd, addr0, pgsize, writebuf);
 	if (err)
@@ -235,7 +235,7 @@ static int erasecrosstest(void)
 		return err;
 
 	pr_info("writing 1st page of block %d\n", ebnum);
-	prandom_bytes_state(&rnd_state, writebuf, pgsize);
+	predictable_rng_prandom_bytes_state(&rnd_state, writebuf, pgsize);
 	strcpy(writebuf, "There is no data like this!");
 	err = mtdtest_write(mtd, addr0, pgsize, writebuf);
 	if (err)
@@ -284,7 +284,7 @@ static int erasetest(void)
 		return err;
 
 	pr_info("writing 1st page of block %d\n", ebnum);
-	prandom_bytes_state(&rnd_state, writebuf, pgsize);
+	predictable_rng_prandom_bytes_state(&rnd_state, writebuf, pgsize);
 	err = mtdtest_write(mtd, addr0, pgsize, writebuf);
 	if (err)
 		return err;

--- a/drivers/mtd/tests/subpagetest.c
+++ b/drivers/mtd/tests/subpagetest.c
@@ -46,7 +46,7 @@ static int write_eraseblock(int ebnum)
 	int err = 0;
 	loff_t addr = (loff_t)ebnum * mtd->erasesize;
 
-	prandom_bytes_state(&rnd_state, writebuf, subpgsize);
+	predictable_rng_prandom_bytes_state(&rnd_state, writebuf, subpgsize);
 	err = mtd_write(mtd, addr, subpgsize, &written, writebuf);
 	if (unlikely(err || written != subpgsize)) {
 		pr_err("error: write failed at %#llx\n",
@@ -60,7 +60,7 @@ static int write_eraseblock(int ebnum)
 
 	addr += subpgsize;
 
-	prandom_bytes_state(&rnd_state, writebuf, subpgsize);
+	predictable_rng_prandom_bytes_state(&rnd_state, writebuf, subpgsize);
 	err = mtd_write(mtd, addr, subpgsize, &written, writebuf);
 	if (unlikely(err || written != subpgsize)) {
 		pr_err("error: write failed at %#llx\n",
@@ -84,7 +84,7 @@ static int write_eraseblock2(int ebnum)
 	for (k = 1; k < 33; ++k) {
 		if (addr + (subpgsize * k) > (loff_t)(ebnum + 1) * mtd->erasesize)
 			break;
-		prandom_bytes_state(&rnd_state, writebuf, subpgsize * k);
+		predictable_rng_prandom_bytes_state(&rnd_state, writebuf, subpgsize * k);
 		err = mtd_write(mtd, addr, subpgsize * k, &written, writebuf);
 		if (unlikely(err || written != subpgsize * k)) {
 			pr_err("error: write failed at %#llx\n",
@@ -120,7 +120,7 @@ static int verify_eraseblock(int ebnum)
 	int err = 0;
 	loff_t addr = (loff_t)ebnum * mtd->erasesize;
 
-	prandom_bytes_state(&rnd_state, writebuf, subpgsize);
+	predictable_rng_prandom_bytes_state(&rnd_state, writebuf, subpgsize);
 	clear_data(readbuf, subpgsize);
 	err = mtd_read(mtd, addr, subpgsize, &read, readbuf);
 	if (unlikely(err || read != subpgsize)) {
@@ -147,7 +147,7 @@ static int verify_eraseblock(int ebnum)
 
 	addr += subpgsize;
 
-	prandom_bytes_state(&rnd_state, writebuf, subpgsize);
+	predictable_rng_prandom_bytes_state(&rnd_state, writebuf, subpgsize);
 	clear_data(readbuf, subpgsize);
 	err = mtd_read(mtd, addr, subpgsize, &read, readbuf);
 	if (unlikely(err || read != subpgsize)) {
@@ -184,7 +184,7 @@ static int verify_eraseblock2(int ebnum)
 	for (k = 1; k < 33; ++k) {
 		if (addr + (subpgsize * k) > (loff_t)(ebnum + 1) * mtd->erasesize)
 			break;
-		prandom_bytes_state(&rnd_state, writebuf, subpgsize * k);
+		predictable_rng_prandom_bytes_state(&rnd_state, writebuf, subpgsize * k);
 		clear_data(readbuf, subpgsize * k);
 		err = mtd_read(mtd, addr, subpgsize * k, &read, readbuf);
 		if (unlikely(err || read != subpgsize * k)) {

--- a/drivers/scsi/fcoe/fcoe_ctlr.c
+++ b/drivers/scsi/fcoe/fcoe_ctlr.c
@@ -2224,7 +2224,7 @@ static void fcoe_ctlr_vn_restart(struct fcoe_ctlr *fip)
 	 */
 	port_id = fip->port_id;
 	if (fip->probe_tries)
-		port_id = prandom_u32_state(&fip->rnd_state) & 0xffff;
+		port_id = predictable_rng_prandom_u32_state(&fip->rnd_state) & 0xffff;
 	else if (!port_id)
 		port_id = fip->lp->wwpn & 0xffff;
 	if (!port_id || port_id == 0xffff)

--- a/include/linux/bpf.h
+++ b/include/linux/bpf.h
@@ -2681,7 +2681,6 @@ const struct bpf_func_proto *tracing_prog_func_proto(
   enum bpf_func_id func_id, const struct bpf_prog *prog);
 
 /* Shared helpers among cBPF and eBPF. */
-void bpf_user_rnd_init_once(void);
 u64 bpf_user_rnd_u32(u64 r1, u64 r2, u64 r3, u64 r4, u64 r5);
 u64 bpf_get_raw_cpu_id(u64 r1, u64 r2, u64 r3, u64 r4, u64 r5);
 

--- a/include/linux/prandom.h
+++ b/include/linux/prandom.h
@@ -16,8 +16,8 @@ struct rnd_state {
 	__u32 s1, s2, s3, s4;
 };
 
-u32 prandom_u32_state(struct rnd_state *state);
-void prandom_bytes_state(struct rnd_state *state, void *buf, size_t nbytes);
+u32 predictable_rng_prandom_u32_state(struct rnd_state *state);
+void predictable_rng_prandom_bytes_state(struct rnd_state *state, void *buf, size_t nbytes);
 void prandom_seed_full_state(struct rnd_state __percpu *pcpu_state);
 
 #define prandom_init_once(pcpu_state)			\
@@ -52,7 +52,7 @@ static inline u32 __seed(u32 x, u32 m)
 }
 
 /**
- * prandom_seed_state - set seed for prandom_u32_state().
+ * prandom_seed_state - set seed for predictable_rng_prandom_u32_state().
  * @state: pointer to state structure to receive the seed.
  * @seed: arbitrary 64-bit value to use as a seed.
  */

--- a/kernel/bpf/core.c
+++ b/kernel/bpf/core.c
@@ -2589,13 +2589,6 @@ void bpf_prog_free(struct bpf_prog *fp)
 }
 EXPORT_SYMBOL_GPL(bpf_prog_free);
 
-/* RNG for unpriviledged user space with separated state from prandom_u32(). */
-static DEFINE_PER_CPU(struct rnd_state, bpf_user_rnd_state);
-
-void bpf_user_rnd_init_once(void)
-{
-	prandom_init_once(&bpf_user_rnd_state);
-}
 
 BPF_CALL_0(bpf_user_rnd_u32)
 {
@@ -2605,12 +2598,8 @@ BPF_CALL_0(bpf_user_rnd_u32)
 	 * transformations. Register assignments from both sides are
 	 * different, f.e. classic always sets fn(ctx, A, X) here.
 	 */
-	struct rnd_state *state;
 	u32 res;
-
-	state = &get_cpu_var(bpf_user_rnd_state);
-	res = predictable_rng_prandom_u32_state(state);
-	put_cpu_var(bpf_user_rnd_state);
+	res = get_random_u32();
 
 	return res;
 }

--- a/kernel/bpf/core.c
+++ b/kernel/bpf/core.c
@@ -2609,7 +2609,7 @@ BPF_CALL_0(bpf_user_rnd_u32)
 	u32 res;
 
 	state = &get_cpu_var(bpf_user_rnd_state);
-	res = prandom_u32_state(state);
+	res = predictable_rng_prandom_u32_state(state);
 	put_cpu_var(bpf_user_rnd_state);
 
 	return res;

--- a/kernel/bpf/verifier.c
+++ b/kernel/bpf/verifier.c
@@ -15681,8 +15681,6 @@ static int do_misc_fixups(struct bpf_verifier_env *env)
 
 		if (insn->imm == BPF_FUNC_get_route_realm)
 			prog->dst_needed = 1;
-		if (insn->imm == BPF_FUNC_get_prandom_u32)
-			bpf_user_rnd_init_once();
 		if (insn->imm == BPF_FUNC_override_return)
 			prog->kprobe_override = 1;
 		if (insn->imm == BPF_FUNC_tail_call) {

--- a/lib/interval_tree_test.c
+++ b/lib/interval_tree_test.c
@@ -43,8 +43,8 @@ static void init(void)
 	int i;
 
 	for (i = 0; i < nnodes; i++) {
-		u32 b = (prandom_u32_state(&rnd) >> 4) % max_endpoint;
-		u32 a = (prandom_u32_state(&rnd) >> 4) % b;
+		u32 b = (predictable_rng_prandom_u32_state(&rnd) >> 4) % max_endpoint;
+		u32 a = (predictable_rng_prandom_u32_state(&rnd) >> 4) % b;
 
 		nodes[i].start = a;
 		nodes[i].last = b;
@@ -56,7 +56,7 @@ static void init(void)
 	 * which is pointless.
 	 */
 	for (i = 0; i < nsearches; i++)
-		queries[i] = (prandom_u32_state(&rnd) >> 4) % max_endpoint;
+		queries[i] = (predictable_rng_prandom_u32_state(&rnd) >> 4) % max_endpoint;
 }
 
 static int interval_tree_test_init(void)

--- a/lib/random32.c
+++ b/lib/random32.c
@@ -43,13 +43,13 @@
 #include <asm/unaligned.h>
 
 /**
- *	prandom_u32_state - seeded pseudo-random number generator.
+ *	predictable_rng_prandom_u32_state - seeded pseudo-random number generator.
  *	@state: pointer to state structure holding seeded state.
  *
  *	This is used for pseudo-randomness with no outside seeding.
  *	For more random results, use get_random_u32().
  */
-u32 prandom_u32_state(struct rnd_state *state)
+u32 predictable_rng_prandom_u32_state(struct rnd_state *state)
 {
 #define TAUSWORTHE(s, a, b, c, d) ((s & c) << d) ^ (((s << a) ^ s) >> b)
 	state->s1 = TAUSWORTHE(state->s1,  6U, 13U, 4294967294U, 18U);
@@ -59,10 +59,10 @@ u32 prandom_u32_state(struct rnd_state *state)
 
 	return (state->s1 ^ state->s2 ^ state->s3 ^ state->s4);
 }
-EXPORT_SYMBOL(prandom_u32_state);
+EXPORT_SYMBOL(predictable_rng_prandom_u32_state);
 
 /**
- *	prandom_bytes_state - get the requested number of pseudo-random bytes
+ *	predictable_rng_prandom_bytes_state - get the requested number of pseudo-random bytes
  *
  *	@state: pointer to state structure holding seeded state.
  *	@buf: where to copy the pseudo-random bytes to
@@ -71,18 +71,18 @@ EXPORT_SYMBOL(prandom_u32_state);
  *	This is used for pseudo-randomness with no outside seeding.
  *	For more random results, use get_random_bytes().
  */
-void prandom_bytes_state(struct rnd_state *state, void *buf, size_t bytes)
+void predictable_rng_prandom_bytes_state(struct rnd_state *state, void *buf, size_t bytes)
 {
 	u8 *ptr = buf;
 
 	while (bytes >= sizeof(u32)) {
-		put_unaligned(prandom_u32_state(state), (u32 *) ptr);
+		put_unaligned(predictable_rng_prandom_u32_state(state), (u32 *) ptr);
 		ptr += sizeof(u32);
 		bytes -= sizeof(u32);
 	}
 
 	if (bytes > 0) {
-		u32 rem = prandom_u32_state(state);
+		u32 rem = predictable_rng_prandom_u32_state(state);
 		do {
 			*ptr++ = (u8) rem;
 			bytes--;
@@ -90,21 +90,21 @@ void prandom_bytes_state(struct rnd_state *state, void *buf, size_t bytes)
 		} while (bytes > 0);
 	}
 }
-EXPORT_SYMBOL(prandom_bytes_state);
+EXPORT_SYMBOL(predictable_rng_prandom_bytes_state);
 
 static void prandom_warmup(struct rnd_state *state)
 {
 	/* Calling RNG ten times to satisfy recurrence condition */
-	prandom_u32_state(state);
-	prandom_u32_state(state);
-	prandom_u32_state(state);
-	prandom_u32_state(state);
-	prandom_u32_state(state);
-	prandom_u32_state(state);
-	prandom_u32_state(state);
-	prandom_u32_state(state);
-	prandom_u32_state(state);
-	prandom_u32_state(state);
+	predictable_rng_prandom_u32_state(state);
+	predictable_rng_prandom_u32_state(state);
+	predictable_rng_prandom_u32_state(state);
+	predictable_rng_prandom_u32_state(state);
+	predictable_rng_prandom_u32_state(state);
+	predictable_rng_prandom_u32_state(state);
+	predictable_rng_prandom_u32_state(state);
+	predictable_rng_prandom_u32_state(state);
+	predictable_rng_prandom_u32_state(state);
+	predictable_rng_prandom_u32_state(state);
 }
 
 void prandom_seed_full_state(struct rnd_state __percpu *pcpu_state)
@@ -265,7 +265,7 @@ static int __init prandom_state_selftest(void)
 		prandom_state_selftest_seed(&state, test1[i].seed);
 		prandom_warmup(&state);
 
-		if (test1[i].result != prandom_u32_state(&state))
+		if (test1[i].result != predictable_rng_prandom_u32_state(&state))
 			error = true;
 	}
 
@@ -281,9 +281,9 @@ static int __init prandom_state_selftest(void)
 		prandom_warmup(&state);
 
 		for (j = 0; j < test2[i].iteration - 1; j++)
-			prandom_u32_state(&state);
+			predictable_rng_prandom_u32_state(&state);
 
-		if (test2[i].result != prandom_u32_state(&state))
+		if (test2[i].result != predictable_rng_prandom_u32_state(&state))
 			errors++;
 
 		runs++;

--- a/lib/rbtree_test.c
+++ b/lib/rbtree_test.c
@@ -150,8 +150,8 @@ static void init(void)
 {
 	int i;
 	for (i = 0; i < nnodes; i++) {
-		nodes[i].key = prandom_u32_state(&rnd);
-		nodes[i].val = prandom_u32_state(&rnd);
+		nodes[i].key = predictable_rng_prandom_u32_state(&rnd);
+		nodes[i].val = predictable_rng_prandom_u32_state(&rnd);
 	}
 }
 

--- a/lib/test_bpf.c
+++ b/lib/test_bpf.c
@@ -140,7 +140,7 @@ static int bpf_fill_maxinsns3(struct bpf_test *self)
 	prandom_seed_state(&rnd, 3141592653589793238ULL);
 
 	for (i = 0; i < len - 1; i++) {
-		__u32 k = prandom_u32_state(&rnd);
+		__u32 k = predictable_rng_prandom_u32_state(&rnd);
 
 		insn[i] = __BPF_STMT(BPF_ALU | BPF_ADD | BPF_K, k);
 	}

--- a/lib/test_parman.c
+++ b/lib/test_parman.c
@@ -136,7 +136,7 @@ static void test_parman_rnd_init(struct test_parman *test_parman)
 
 static u32 test_parman_rnd_get(struct test_parman *test_parman)
 {
-	return prandom_u32_state(&test_parman->rnd);
+	return predictable_rng_prandom_u32_state(&test_parman->rnd);
 }
 
 static unsigned long test_parman_priority_gen(struct test_parman *test_parman)

--- a/lib/test_scanf.c
+++ b/lib/test_scanf.c
@@ -269,16 +269,16 @@ static void __init numbers_simple(void)
  */
 static u32 __init next_test_random(u32 max_bits)
 {
-	u32 n_bits = hweight32(prandom_u32_state(&rnd_state)) % (max_bits + 1);
+	u32 n_bits = hweight32(predictable_rng_prandom_u32_state(&rnd_state)) % (max_bits + 1);
 
-	return prandom_u32_state(&rnd_state) & GENMASK(n_bits, 0);
+	return predictable_rng_prandom_u32_state(&rnd_state) & GENMASK(n_bits, 0);
 }
 
 static unsigned long long __init next_test_random_ull(void)
 {
-	u32 rand1 = prandom_u32_state(&rnd_state);
+	u32 rand1 = predictable_rng_prandom_u32_state(&rnd_state);
 	u32 n_bits = (hweight32(rand1) * 3) % 64;
-	u64 val = (u64)prandom_u32_state(&rnd_state) * rand1;
+	u64 val = (u64)predictable_rng_prandom_u32_state(&rnd_state) * rand1;
 
 	return val & GENMASK_ULL(n_bits, 0);
 }

--- a/mm/slab.c
+++ b/mm/slab.c
@@ -2447,7 +2447,7 @@ static bool shuffle_freelist(struct kmem_cache *cachep, struct slab *slab)
 
 		/* Fisher-Yates shuffle */
 		for (i = count - 1; i > 0; i--) {
-			rand = prandom_u32_state(&state.rnd_state);
+			rand = predictable_rng_prandom_u32_state(&state.rnd_state);
 			rand %= (i + 1);
 			swap_free_obj(slab, i, rand);
 		}

--- a/mm/slab_common.c
+++ b/mm/slab_common.c
@@ -1141,7 +1141,7 @@ static void freelist_randomize(struct rnd_state *state, unsigned int *list,
 
 	/* Fisher-Yates shuffle */
 	for (i = count - 1; i > 0; i--) {
-		rand = prandom_u32_state(state);
+		rand = predictable_rng_prandom_u32_state(state);
 		rand %= (i + 1);
 		swap(list[i], list[rand]);
 	}

--- a/net/core/filter.c
+++ b/net/core/filter.c
@@ -444,7 +444,6 @@ static bool convert_bpf_extensions(struct sock_filter *fp,
 			break;
 		case SKF_AD_OFF + SKF_AD_RANDOM:
 			*insn = BPF_EMIT_CALL(bpf_user_rnd_u32);
-			bpf_user_rnd_init_once();
 			break;
 		}
 		break;


### PR DESCRIPTION
Pull request for series with
subject: Replace invocations of prandom_u32 with get_random_u32
version: 1
url: https://patchwork.kernel.org/project/netdevbpf/list/?series=703679
