### PR TITLE
bpf/selftests: Use parent instead of last_wakee in task kfunc test

### DIFF
--- a/tools/testing/selftests/bpf/progs/task_kfunc_failure.c
+++ b/tools/testing/selftests/bpf/progs/task_kfunc_failure.c
@@ -73,7 +73,7 @@ int BPF_PROG(task_kfunc_acquire_trusted_walked, struct task_struct *task, u64 cl
 	struct task_struct *acquired;
 
 	/* Can't invoke bpf_task_acquire() on a trusted pointer obtained from walking a struct. */
-	acquired = bpf_task_acquire(task->last_wakee);
+	acquired = bpf_task_acquire(task->parent);
 	bpf_task_release(acquired);
 
 	return 0;


### PR DESCRIPTION
Pull request for series with
subject: bpf/selftests: Use parent instead of last_wakee in task kfunc test
version: 1
url: https://patchwork.kernel.org/project/netdevbpf/list/?series=703973
