### PR TITLE
selftests/bpf: enable mptcp before testing

### DIFF
--- a/tools/testing/selftests/bpf/prog_tests/select_reuseport.c
+++ b/tools/testing/selftests/bpf/prog_tests/select_reuseport.c
@@ -56,13 +56,6 @@ static union sa46 {
 	}								\
 })
 
-#define RET_ERR(condition, tag, format...) ({				\
-	if (CHECK_FAIL(condition)) {					\
-		printf(tag " " format);					\
-		return -1;						\
-	}								\
-})
-
 static int create_maps(enum bpf_map_type inner_type)
 {
 	LIBBPF_OPTS(bpf_map_create_opts, opts);
@@ -155,42 +148,6 @@ static void sa46_init_inany(union sa46 *sa, sa_family_t family)
 		sa->v6.sin6_addr = in6addr_any;
 	else
 		sa->v4.sin_addr.s_addr = INADDR_ANY;
-}
-
-static int read_int_sysctl(const char *sysctl)
-{
-	char buf[16];
-	int fd, ret;
-
-	fd = open(sysctl, 0);
-	RET_ERR(fd == -1, "open(sysctl)",
-		"sysctl:%s fd:%d errno:%d\n", sysctl, fd, errno);
-
-	ret = read(fd, buf, sizeof(buf));
-	RET_ERR(ret <= 0, "read(sysctl)",
-		"sysctl:%s ret:%d errno:%d\n", sysctl, ret, errno);
-
-	close(fd);
-	return atoi(buf);
-}
-
-static int write_int_sysctl(const char *sysctl, int v)
-{
-	int fd, ret, size;
-	char buf[16];
-
-	fd = open(sysctl, O_RDWR);
-	RET_ERR(fd == -1, "open(sysctl)",
-		"sysctl:%s fd:%d errno:%d\n", sysctl, fd, errno);
-
-	size = snprintf(buf, sizeof(buf), "%d", v);
-	ret = write(fd, buf, size);
-	RET_ERR(ret != size, "write(sysctl)",
-		"sysctl:%s ret:%d size:%d errno:%d\n",
-		sysctl, ret, size, errno);
-
-	close(fd);
-	return 0;
 }
 
 static void restore_sysctls(void)

--- a/tools/testing/selftests/bpf/test_progs.c
+++ b/tools/testing/selftests/bpf/test_progs.c
@@ -967,6 +967,42 @@ int write_sysctl(const char *sysctl, const char *value)
 	return 0;
 }
 
+int read_int_sysctl(const char *sysctl)
+{
+	char buf[16];
+	int fd, ret;
+
+	fd = open(sysctl, 0);
+	RET_ERR(fd == -1, "open(sysctl)",
+		"sysctl:%s fd:%d errno:%d\n", sysctl, fd, errno);
+
+	ret = read(fd, buf, sizeof(buf));
+	RET_ERR(ret <= 0, "read(sysctl)",
+		"sysctl:%s ret:%d errno:%d\n", sysctl, ret, errno);
+
+	close(fd);
+	return atoi(buf);
+}
+
+int write_int_sysctl(const char *sysctl, int v)
+{
+	int fd, ret, size;
+	char buf[16];
+
+	fd = open(sysctl, O_RDWR);
+	RET_ERR(fd == -1, "open(sysctl)",
+		"sysctl:%s fd:%d errno:%d\n", sysctl, fd, errno);
+
+	size = snprintf(buf, sizeof(buf), "%d", v);
+	ret = write(fd, buf, size);
+	RET_ERR(ret != size, "write(sysctl)",
+		"sysctl:%s ret:%d size:%d errno:%d\n",
+		sysctl, ret, size, errno);
+
+	close(fd);
+	return 0;
+}
+
 #define MAX_BACKTRACE_SZ 128
 void crash_handler(int signum)
 {

--- a/tools/testing/selftests/bpf/test_progs.h
+++ b/tools/testing/selftests/bpf/test_progs.h
@@ -376,6 +376,13 @@ int test__join_cgroup(const char *path);
 	___ok;								\
 })
 
+#define RET_ERR(condition, tag, format...) ({				\
+	if (CHECK_FAIL(condition)) {					\
+		printf(tag " " format);					\
+		return -1;						\
+	}								\
+})
+
 static inline __u64 ptr_to_u64(const void *ptr)
 {
 	return (__u64) (unsigned long) ptr;
@@ -394,6 +401,8 @@ int kern_sync_rcu(void);
 int trigger_module_test_read(int read_sz);
 int trigger_module_test_write(int write_sz);
 int write_sysctl(const char *sysctl, const char *value);
+int read_int_sysctl(const char *sysctl);
+int write_int_sysctl(const char *sysctl, int v);
 
 #ifdef __x86_64__
 #define SYS_NANOSLEEP_KPROBE_NAME "__x64_sys_nanosleep"


### PR DESCRIPTION
Pull request for series with
subject: selftests/bpf: enable mptcp before testing
version: 1
url: https://patchwork.kernel.org/project/netdevbpf/list/?series=720600
