### PR TITLE
net: Fix slab-out-of-bounds in inet[6]_steal_sock

### DIFF
--- a/include/net/inet6_hashtables.h
+++ b/include/net/inet6_hashtables.h
@@ -116,7 +116,7 @@ struct sock *inet6_steal_sock(struct net *net, struct sk_buff *skb, int doff,
 	if (!sk)
 		return NULL;
 
-	if (!prefetched)
+	if (!prefetched || !sk_fullsock(sk))
 		return sk;
 
 	if (sk->sk_protocol == IPPROTO_TCP) {

--- a/include/net/inet_hashtables.h
+++ b/include/net/inet_hashtables.h
@@ -462,7 +462,7 @@ struct sock *inet_steal_sock(struct net *net, struct sk_buff *skb, int doff,
 	if (!sk)
 		return NULL;
 
-	if (!prefetched)
+	if (!prefetched || !sk_fullsock(sk))
 		return sk;
 
 	if (sk->sk_protocol == IPPROTO_TCP) {


### PR DESCRIPTION
Pull request for series with
subject: net: Fix slab-out-of-bounds in inet[6]_steal_sock
version: 2
url: https://patchwork.kernel.org/project/netdevbpf/list/?series=776226
