### PR TITLE
samples/bpf: syscall_tp_user: Refactor and fix array index out-of-bounds bug

### DIFF
--- a/samples/bpf/Makefile
+++ b/samples/bpf/Makefile
@@ -169,6 +169,9 @@ endif
 TPROGS_CFLAGS += -Wall -O2
 TPROGS_CFLAGS += -Wmissing-prototypes
 TPROGS_CFLAGS += -Wstrict-prototypes
+TPROGS_CFLAGS += $(call try-run,\
+	printf "int main() { return 0; }" |\
+	$(CC) -Werror -fsanitize=bounds -x c - -o "$$TMP",-fsanitize=bounds,)
 
 TPROGS_CFLAGS += -I$(objtree)/usr/include
 TPROGS_CFLAGS += -I$(srctree)/tools/testing/selftests/bpf/


### PR DESCRIPTION
Pull request for series with
subject: samples/bpf: syscall_tp_user: Refactor and fix array index out-of-bounds bug
version: 2
url: https://patchwork.kernel.org/project/netdevbpf/list/?series=785032
